### PR TITLE
Fix for issue #20

### DIFF
--- a/src/demuxer.js
+++ b/src/demuxer.js
@@ -44,7 +44,7 @@ var FLACDemuxer = AV.Demuxer.extend(function() {
         }
         
         while (stream.available(1) && !this.last) {                     
-            if (!this.readBlockHeaders) {
+            if (!this.readBlockHeaders && !this.waitingForStreamData) {
                 var tmp = stream.readUInt8();
                 this.last = (tmp & 0x80) === 0x80,
                 this.type = tmp & 0x7F,
@@ -54,8 +54,12 @@ var FLACDemuxer = AV.Demuxer.extend(function() {
             if (!this.foundStreamInfo && this.type !== STREAMINFO)
                 return this.emit('error', 'STREAMINFO must be the first block');
                 
-            if (!stream.available(this.size))
+            if (!stream.available(this.size)){
+                this.waitingForStreamData=true;
                 return;
+            } else {
+                this.waitingForStreamData=false;
+            }
             
             switch (this.type) {
                 case STREAMINFO:

--- a/src/demuxer.js
+++ b/src/demuxer.js
@@ -44,7 +44,7 @@ var FLACDemuxer = AV.Demuxer.extend(function() {
         }
         
         while (stream.available(1) && !this.last) {                     
-            if (!this.readBlockHeaders && !this.waitingForStreamData) {
+            if (!this.readBlockHeaders) {
                 var tmp = stream.readUInt8();
                 this.last = (tmp & 0x80) === 0x80,
                 this.type = tmp & 0x7F,
@@ -55,10 +55,10 @@ var FLACDemuxer = AV.Demuxer.extend(function() {
                 return this.emit('error', 'STREAMINFO must be the first block');
                 
             if (!stream.available(this.size)){
-                this.waitingForStreamData=true;
+                this.readBlockHeaders=true;
                 return;
             } else {
-                this.waitingForStreamData=false;
+                this.readBlockHeaders=false;
             }
             
             switch (this.type) {


### PR DESCRIPTION
This change stops the blockHeader stream data from being discarded if you've read enough data to determine the blockHeader type and size, but there's not enough available to read the blockHeader data.
